### PR TITLE
args: fix argument number format in error messages

### DIFF
--- a/lua-nucleo/args.lua
+++ b/lua-nucleo/args.lua
@@ -56,8 +56,8 @@ do
       if type(value) ~= expected_type then
         if not lua_types[expected_type] then
           error(
-              "argument #" .. ((i + 1) * 0.5) .. ": bad expected type `"
-              .. tostring(expected_type) .. "'",
+              "argument #" .. math.floor((i + 1) * 0.5)
+              .. ": bad expected type `" .. tostring(expected_type) .. "'",
               3
             )
         end
@@ -65,7 +65,7 @@ do
         if not is_optional or value ~= nil then
           error(
               (is_optional and "optional " or "")
-              .. "argument #" .. ((i + 1) * 0.5) .. ": expected `"
+              .. "argument #" .. math.floor(((i + 1) * 0.5)) .. ": expected `"
               .. tostring(expected_type) .. "', got `" .. type(value) .. "'",
               3
             )


### PR DESCRIPTION
Started from Lua 5.3 the `0020-args` test suite is failed with:
```
[run]   test/cases/0020-args.lua        Suite `args' failed:
 * Test `arguments': lua-nucleo/ensure.lua:632: ensure_fails_with_substring failed: bad type: can't find expected substring `argument #1: bad expected type `garbage'' in error message:
test/cases/0020-args.lua:139: argument #1.0: bad expected type `garbage'
 * Test `method_arguments': lua-nucleo/ensure.lua:632: ensure_fails_with_substring failed: bad type: can't find expected substring `argument #1: bad expected type `garbage'' in error message:
test/cases/0020-args.lua:139: argument #1.0: bad expected type `garbage'
 * Test `optional_arguments': lua-nucleo/ensure.lua:632: ensure_fails_with_substring failed: bad type: can't find expected substring `argument #1: bad expected type `garbage'' in error message:
test/cases/0020-args.lua:222: argument #1.0: bad expected type `garbage'
```

Expected that error would be "argument #1: bad expected type `garbage'".

The reason is that starting from Lua 5.3 a whole number can be with the fractional part and without it.

Lua 5.1 and Lua 5.2:
```
> lua -e "print(2)"
2
> lua -e "print(2.0)"
2
> lua -e "print(2 * 0.5)"
1
```

Lua 5.3 and Lua 5.4:
```
> lua -e "print(2)"
2
> lua -e "print(2.0)"
2.0
> lua -e "print(2 * 0.5)"
1.0
```

`math.floor` is able to get rid of the fractional part. So, we use it to fix the error message in lua-nucleo/args.lua