### PR TITLE
test/cases/0060-deque: fix tests

### DIFF
--- a/lua-nucleo/deque.lua
+++ b/lua-nucleo/deque.lua
@@ -43,8 +43,12 @@ do
     return table_remove(self, 1)
   end
 
+  -- Not letting user to affect us with setting self[0] on construction
   local pop_back = function(self)
-    return table_remove(self)
+    if #self > 0 then
+      return table_remove(self)
+    end
+    return nil
   end
 
   local mt =


### PR DESCRIPTION
deque-empty-pre-set-back fails in Lua >5.1

```
Suite test      deque-empty-pre-set-back
test/cases/0060-deque.lua:243: ensure_equals failed: empty pop_back: actual `EMPTY', expected `nil'
stack traceback:
        [C]: in function 'error'
        lua-nucleo/ensure.lua:70: in function 'ensure_equals'
        test/cases/0060-deque.lua:243: in function 'fn'
        lua-nucleo/suite.lua:177: in function <lua-nucleo/suite.lua:177>
        [C]: in function 'xpcall'
        lua-nucleo/suite.lua:177: in function 'run'
        lua-nucleo/suite.lua:672: in function <lua-nucleo/suite.lua:668>
        [C]: in function 'xpcall'
        lua-nucleo/suite.lua:667: in function 'run_test'
        lua-nucleo/suite.lua:718: in function 'run_tests'
        test/test.lua:171: in main chunk
        [C]: in ?
```

The reason is that table.remove returns different results in Lua 5.1 and fresher:

```
local t = { [0] = "Zero" }
local remove_result = table.remove(t)
print(type(remove_result), tostring(remove_result)) -- "nil, nil" in Lua 5.1
print(type(remove_result), tostring(remove_result)) -- "string, Zero" in Lua >5.1
```