### PR TITLE
test/cases/0270-ensure: fix ensure_error_with_substring-is-happy-on-f…

### DIFF
--- a/test/cases/0270-ensure.lua
+++ b/test/cases/0270-ensure.lua
@@ -137,10 +137,13 @@ test:tests_for "ensure_error_with_substring"
 
 test:case "ensure_error_with_substring-is-happy-on-failure" (function()
   local res, err = loadstring("boo")
+  local expected_error = _VERSION == 'Lua 5.1'
+    and [=[[string "boo"]:1: '=' expected near '<eof>']=]
+     or [=[[string "boo"]:1: syntax error near <eof>]=]
   local res, err = pcall(function()
     ensure_error_with_substring(
         "inner msg",
-        [=[[string "boo"]:1: '=' expected near '<eof>']=],
+        expected_error,
         res,
         err
       )
@@ -313,10 +316,13 @@ test:tests_for "ensure_error"
 
 test:case "ensure_error-is-happy-on-failure" (function()
   local res, err = loadstring("boo")
+  local expected_error = _VERSION == 'Lua 5.1'
+    and [=[[string "boo"]:1: '=' expected near '<eof>']=]
+     or [=[[string "boo"]:1: syntax error near <eof>]=]
   local res, err = pcall(function()
     ensure_error(
         "inner msg",
-        [=[[string "boo"]:1: '=' expected near '<eof>']=],
+        expected_error,
         res,
         err
       )


### PR DESCRIPTION
…ailure and ensure_error-is-happy-on-failure tests

2 tests fail on Lua >5.1

```
Suite test      ensure_error_with_substring-is-happy-on-failure
test/cases/0270-ensure.lua:148: ensure failed: should not throw error
stack traceback:
        [C]: in function 'error'
        lua-nucleo/ensure.lua:52: in upvalue 'ensure'
        test/cases/0270-ensure.lua:148: in field 'fn'
        lua-nucleo/suite.lua:177: in function <lua-nucleo/suite.lua:177>
        [C]: in function 'xpcall'
        lua-nucleo/suite.lua:177: in upvalue 'run'
        lua-nucleo/suite.lua:672: in function <lua-nucleo/suite.lua:668>
        [C]: in function 'xpcall'
        lua-nucleo/suite.lua:667: in upvalue 'run_test'
        lua-nucleo/suite.lua:718: in local 'run_tests'
        test/test.lua:171: in main chunk
        [C]: in ?

Suite test      ensure_error-is-happy-on-failure
test/cases/0270-ensure.lua:324: ensure failed: should not throw error
stack traceback:
        [C]: in function 'error'
        lua-nucleo/ensure.lua:52: in upvalue 'ensure'
        test/cases/0270-ensure.lua:324: in field 'fn'
        lua-nucleo/suite.lua:177: in function <lua-nucleo/suite.lua:177>
        [C]: in function 'xpcall'
        lua-nucleo/suite.lua:177: in upvalue 'run'
        lua-nucleo/suite.lua:672: in function <lua-nucleo/suite.lua:668>
        [C]: in function 'xpcall'
        lua-nucleo/suite.lua:667: in upvalue 'run_test'
        lua-nucleo/suite.lua:718: in local 'run_tests'
        test/test.lua:171: in main chunk
        [C]: in ?
```

The reason is in `loadstring` produces different errors in Lua 5.1 and newer
versions. `loadstring` in Lua >5.1 is emulated via `load` and generalized
to the `legacy` module of Lua-Núcleo.

`loadstring("boo")`
- fails with `[string "boo"]:1: '=' expected near '<eof>'` in Lua 5.1
- fails with `[string "boo"]:1: syntax error near <eof>` in Lua >5.1

Both cases are handled.