### PR TITLE
lua-nucleo/tstr: fix serialization with metatables

### DIFF
--- a/lua-nucleo/tstr.lua
+++ b/lua-nucleo/tstr.lua
@@ -24,15 +24,14 @@ do
 
         -- Serialize numeric indices
 
-        local next_i = 0
-        for i, v in ipairs(t) do -- TODO: Lua 5.2 warning. Rewrite.
+        for i = 1, #t do
           if i > 1 then -- TODO: Move condition out of the loop
             cat(",")
           end
-          impl(v, cat, visited)
-          next_i = i
+          impl(t[i], cat, visited)
         end
-        next_i = next_i + 1
+
+        local next_i = #t + 1
 
         -- Serialize hash part
         -- Skipping comma only at first element if there is no numeric part.


### PR DESCRIPTION
Suite hangs on `tstr-table-special-cases` and `tstr_cat-table-special-cases`
tests in Lua >=5.3.

The difference is how ipairs works with tables where __index is overridden by
metatable.

```
local t = { }
setmetatable(t, { __index = function() return 42 end })
for i, v in ipairs(t) do
  print(i, v)
  break
end

-- In Lua 5.1 and Lua 5.2 the loop body is skipped.
-- In Lua 5.3 and Lua 5.4 the loop body is executed once, "1, 42" is output, and
-- will be executed infinitely without `break`.
```

`ipairs` is replaced with the common numeric for loop to fix.