### PR TITLE
test/cases/0330-tpretty: fix tpretty_ex-bug-concat-nil-full test

### DIFF
--- a/test/cases/0330-tpretty.lua
+++ b/test/cases/0330-tpretty.lua
@@ -22,14 +22,14 @@ local loadstring
 local ensure,
       ensure_equals,
       ensure_strequals,
-      ensure_tequals,
+      ensure_strvariant,
       ensure_fails_with_substring
       = import 'lua-nucleo/ensure.lua'
       {
         'ensure',
         'ensure_equals',
         'ensure_strequals',
-        'ensure_tequals',
+        'ensure_strvariant',
         'ensure_fails_with_substring'
       }
 
@@ -42,6 +42,12 @@ local tpretty_ex,
         'tpretty_ex',
         'tpretty',
         'tpretty_ordered'
+      }
+
+local tifindallpermutations
+      = import 'lua-nucleo/table-utils.lua'
+      {
+        'tifindallpermutations'
       }
 
 --------------------------------------------------------------------------------
@@ -146,84 +152,117 @@ end)
 test "tpretty_ex-bug-concat-nil-full" (function()
   -- TODO: systematic solution required
   -- https://github.com/lua-nucleo/lua-nucleo/issues/18
-  local s1
-  if jit ~= nil then
-    s1 = [[
-{
-  result =
+
+  local garden_fields =
+  {
+    'views_total = "INTEGER";\n';
+    'unique_visits_total = "INTEGER";\n';
+    'id = "GARDEN_ID";\n';
+    'views_yesterday = "INTEGER";\n';
+    'unique_visits_yesterday = "INTEGER";\n';
+  }
+  local garden_field_permutations = { }
+  tifindallpermutations(garden_fields, garden_field_permutations)
+
+  local result_permutations = { }
+  for i = 1, #garden_field_permutations do
+    local p = garden_field_permutations[i]
+    result_permutations[#result_permutations + 1] =
+[[  result =
   {
     stats =
     {
       garden =
       {
-        views_total = "INTEGER";
-        unique_visits_yesterday = "INTEGER";
-        id = "GARDEN_ID";
-        views_yesterday = "INTEGER";
-        unique_visits_total = "INTEGER";
+        ]] .. p[1] .. [[
+        ]] .. p[2] .. [[
+        ]] .. p[3] .. [[
+        ]] .. p[4] .. [[
+        ]] .. p[5] .. [[
       };
     };
   };
+]]
+  end
+
+  local expected_variants = { }
+  for i = 1, #result_permutations do
+    expected_variants[#expected_variants + 1] = [[
+{
+]] .. result_permutations[i] .. [[
   events = { };
 }]]
-  else
-    s1 = [[
+    expected_variants[#expected_variants + 1] = [[
 {
-  result =
-  {
-    stats =
-    {
-      garden =
-      {
-        views_total = "INTEGER";
-        unique_visits_total = "INTEGER";
-        id = "GARDEN_ID";
-        views_yesterday = "INTEGER";
-        unique_visits_yesterday = "INTEGER";
-      };
-    };
-  };
   events = { };
+]] .. result_permutations[i] .. [[
 }]]
   end
 
-  local s2 = [[
-{
-  result =
-  {
-    money_real = "MONEY_REAL";
-    money_referral = "MONEY_REFERRAL";
-    money_game = "MONEY_GAME";
-  };
-  events = { };
-}]]
-
-  ensure_strequals(
+  ensure_strvariant(
       "first result matches expected",
       ensure(
           "render first",
           tpretty_ex(
               pairs,
-              ensure("parse", loadstring("return " .. s1))(),
+              ensure("parse", loadstring("return " .. expected_variants[1]))(),
               "  ",
               80
             )
         ),
-      s1
+      expected_variants
     )
 
-  ensure_strequals(
-      "second result matches expected",
+  ------------------------------------------------------------------------------
+
+  local result_fields =
+  {
+    'money_real = "MONEY_REAL";\n';
+    'money_referral = "MONEY_REFERRAL";\n';
+    'money_game = "MONEY_GAME";\n';
+  }
+  local result_field_permutations = { }
+  tifindallpermutations(result_fields, result_field_permutations)
+
+  result_permutations = { }
+  for i = 1, #result_field_permutations do
+    local p = result_field_permutations[i]
+    result_permutations[#result_permutations + 1] =
+[[  result =
+  {
+    ]] .. p[1] .. [[
+    ]] .. p[2] .. [[
+    ]] .. p[3] .. [[
+  };
+]]
+  end
+
+  expected_variants = { }
+  for i = 1, #result_permutations do
+    expected_variants[#expected_variants + 1] = [[
+{
+]] .. result_permutations[i] .. [[
+  events = { };
+}]]
+    expected_variants[#expected_variants + 1] = [[
+{
+  events = { };
+]] .. result_permutations[i] .. [[
+}]]
+  end
+
+  ensure_strvariant(
+      "first result matches expected",
       ensure(
-          "render second",
+          "render first",
           tpretty_ex(
               pairs,
-              ensure("parse", loadstring("return " .. s2))(),
+              ensure("parse", loadstring("return " .. expected_variants[1]))(),
               "  ",
               80
             )
         ),
-      s2
+      expected_variants
     )
 end)
 


### PR DESCRIPTION
Table keys traversal order was never been determined in Lua but some tests were written if it is.
That leads to errors in various tests that use key-value tables serialization in newer versions of Lua.

This time:
```
Suite test      tpretty_ex-bug-concat-nil-full
lua-nucleo/ensure.lua:244: ensure_strequals: first result matches expected:
different at byte 5 (line 2, offset 1):

  expected   |{
  result =
  |
vs. actual   |{
  events = { |

actual:
{
  events = { };
  result =
  {
    stats =
    {
      garden =
      {
        unique_visits_total = "INTEGER";
        id = "GARDEN_ID";
        views_total = "INTEGER";
        unique_visits_yesterday = "INTEGER";
        views_yesterday = "INTEGER";
      };
    };
  };
}
expected:
{
  result =
  {
    stats =
    {
      garden =
      {
        views_total = "INTEGER";
        unique_visits_total = "INTEGER";
        id = "GARDEN_ID";
        views_yesterday = "INTEGER";
        unique_visits_yesterday = "INTEGER";
      };
    };
  };
  events = { };
}
stack traceback:
        [C]: in function 'error'
        lua-nucleo/ensure.lua:244: in upvalue 'ensure_strequals'
        test/cases/0330-tpretty.lua:201: in field 'fn'
        lua-nucleo/suite.lua:177: in function <lua-nucleo/suite.lua:177>
        [C]: in function 'xpcall'
        lua-nucleo/suite.lua:177: in upvalue 'run'
        lua-nucleo/suite.lua:672: in function <lua-nucleo/suite.lua:668>
        [C]: in function 'xpcall'
        lua-nucleo/suite.lua:667: in upvalue 'run_test'
        lua-nucleo/suite.lua:718: in local 'run_tests'
        test/test.lua:171: in main chunk
        [C]: in ?
```

Construct possible variants and replace `ensure_strequals` with
`ensure_strvariant` to take all the variants into account.