### PR TITLE
test/cases/0190-table-utils: fix tflip_inplace-many

### DIFF
--- a/test/cases/0190-table-utils.lua
+++ b/test/cases/0190-table-utils.lua
@@ -774,7 +774,9 @@ test "tflip_inplace-many" (function()
 
   ensure(
       "many",
-      tequals(r, { [1] = 42, [42] = 1, [k] = "a", a = k }) or tequals(r, { [1] = 42, [42] = 1, [false] = k, [k] = false, a = k })
+       tequals(r, { [1] = 42, a = k, [k] = "a",   [42] = 1 })
+        or tequals(r, { [1] = 42, a = k, [k] = false, [42] = 1, [false] = k})
+        or tequals(r, { [1] = 42, a = k, [k] = "a",   [42] = 1, [false] = k})
     )
 end)
 


### PR DESCRIPTION
Table keys traversal order was never been determined in Lua but some tests were written if it is.
That leads to errors in various tests that use key-value tables serialization in newer versions of Lua.

This time:
```
Suite test      tflip_inplace-many
test/cases/0190-table-utils.lua:775: ensure failed: many
stack traceback:
        [C]: in function 'error'
        lua-nucleo/ensure.lua:52: in upvalue 'ensure'
        test/cases/0190-table-utils.lua:775: in field 'fn'
        lua-nucleo/suite.lua:177: in function <lua-nucleo/suite.lua:177>
        [C]: in function 'xpcall'
        lua-nucleo/suite.lua:177: in upvalue 'run'
        lua-nucleo/suite.lua:672: in function <lua-nucleo/suite.lua:668>
        [C]: in function 'xpcall'
        lua-nucleo/suite.lua:667: in upvalue 'run_test'
        lua-nucleo/suite.lua:718: in local 'run_tests'
        test/test.lua:171: in main chunk
        [C]: in ?
```

We add additional expected table to cover all possible variants.