### PR TITLE
Fix tdeepequals.ordered_pairs: don't invoke table[nil]

### DIFF
--- a/lua-nucleo/tdeepequals.lua
+++ b/lua-nucleo/tdeepequals.lua
@@ -283,7 +283,10 @@ local ordered_pairs = function(t)
   local ordered_next = function(t)
     local key = keys[i]
     i = i + 1
-    return key, t[key]
+    if key ~= nil then
+      return key, t[key]
+    end
+    return key, nil
   end
 
   return ordered_next, t, nil

--- a/test/cases/0330-tpretty.lua
+++ b/test/cases/0330-tpretty.lua
@@ -536,3 +536,17 @@ end)
 test "tpretty-ordered-globals" (function()
   tpretty_ordered(_G)
 end)
+
+test "tpretty-ordered-with-nil-key-failure" (function()
+  local table_that_dont_like_nil_keys = setmetatable(
+    { },
+    {
+      __index = function(self, key)
+        if key == nil then
+          error('The `nil` key is passed to __index')
+        end
+      end
+    }
+  )
+  tpretty_ordered(table_that_dont_like_nil_keys)
+end)

--- a/test/cases/0330-tpretty.lua
+++ b/test/cases/0330-tpretty.lua
@@ -532,3 +532,7 @@ test "tpretty-ordered" (function()
       expected
     )
 end)
+
+test "tpretty-ordered-globals" (function()
+  tpretty_ordered(_G)
+end)


### PR DESCRIPTION
Reasoning for the fix:
1. It breaks when getting a value by `nil` key from `_G` when the strict mode is on, which is default for lua-nucleo.
2. It breaks `lxsh` module traversing: `__index` in one of the metatables doesn’t expect `nil` keys.

So, it’s seems appropriate to set a definite rule for `nil` keys that `table[nil] == nil` is always true.