### PR TITLE
Fix the "tslice_table_contains_nil" test for LuaJIT

### DIFF
--- a/test/cases/0190-table-utils.lua
+++ b/test/cases/0190-table-utils.lua
@@ -1825,11 +1825,25 @@ end)
 test "tslice_table_contains_nil" (function()
   local t = { 1, nil, 3, nil, nil, 6 }
 
-  ensure_tequals(
+  if #t == 1 then
+    ensure_tequals(
+      "input table contains nil",
+      tslice(t, 1, 6),
+      { 1 }
+    )
+  elseif #t == 3 then
+    ensure_tequals(
+      "input table contains nil",
+      tslice(t, 1, 6),
+      { 1, nil, 3 }
+    )
+  else
+    ensure_tequals(
       "input table contains nil",
       tslice(t, 1, 6),
       { 1, nil, 3, nil, nil, 6 }
     )
+  end
 end)
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Undefined behavior of the original version of the test was not taken into account and due to that the test is failed when running on LuaJIT:
```
test/cases/0190-table-utils.lua:1828: ensure_tequals failed: input table contains nil: bad actual value at key `3': got `nil', expected `3'
stack traceback:
        [C]: in function 'error'
        lua-nucleo/ensure.lua:128: in function 'ensure_tequals'
        test/cases/0190-table-utils.lua:1828: in function 'fn'
        lua-nucleo/suite.lua:177: in function <lua-nucleo/suite.lua:177>
        [C]: in function 'xpcall'
        lua-nucleo/suite.lua:177: in function 'run'
        lua-nucleo/suite.lua:683: in function <lua-nucleo/suite.lua:679>
        [C]: in function 'xpcall'
        lua-nucleo/suite.lua:678: in function 'run_test'
        lua-nucleo/suite.lua:729: in function 'run_tests'
        test/test.lua:171: in main chunk
        [C]: at 0x55edc6de01d0
```

The reason is that the length of `{ 1, nil, 3, nil, nil, 6 }` table is different on original Lua and LuaJIT. Cover all possible cases resolves the issue.